### PR TITLE
Added Neve Dynamics and 33609 plugins

### DIFF
--- a/uad-hide-and-seek.rb
+++ b/uad-hide-and-seek.rb
@@ -522,6 +522,12 @@ def plug_case_statement(plug)
     plugs << "UAD Teletronix LA-3A#{PLUGIN_APPEND}.#{PLUGIN_EXT}/"
   when /UAD Teletronix LA-3A Leveler.#{PLUGIN_EXT}/
     plugs << "UAD Teletronix LA-3A#{PLUGIN_APPEND}.#{PLUGIN_EXT}/"
+  when /UAD Neve Dynamics Collection.#{PLUGIN_EXT}/
+    plugs << "UAD Neve 2254 E Dual#{PLUGIN_APPEND}.#{PLUGIN_EXT}/"
+    plugs << "UAD Neve 2254 E#{PLUGIN_APPEND}.#{PLUGIN_EXT}/"
+  when /UAD Neve 33609 Stereo Limiter Compressor.#{PLUGIN_EXT}/
+    plugs << "UAD Neve 33609SE#{PLUGIN_APPEND}.#{PLUGIN_EXT}/"
+    plugs << "UAD Neve 33609 C#{PLUGIN_APPEND}.#{PLUGIN_EXT}/"
   # New Plugs
   # ---------
   # when /UAD Plugin Name From UADSystemProfile.txt file.#{PLUGIN_EXT}/


### PR DESCRIPTION
The new version of the UAD software includes some new Neve plugins which require exception rules.